### PR TITLE
transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "react-image-crop": "^8.6.1",
     "react-intl": "^4.2.2",
     "react-player": "^2.4.0",
+    "react-transition-group": "^4.4.1",
     "uuid": "^3.4.0"
   },
   "husky": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import {
   createMuiTheme,
   ThemeProvider,
 } from '@material-ui/core/styles';
+import Fade from '@material-ui/core/Fade';
+import { TransitionGroup } from 'react-transition-group';
 import { IntlProvider } from 'react-intl';
 import { useSelector } from 'react-redux';
 import '@formatjs/intl-numberformat/polyfill';
@@ -42,6 +44,7 @@ import RequestInvitation from './pages/auth/RequestInvitation';
 import materialTheme from './styles/materialTheme';
 import messagesEn from '../locale/en.json';
 import messagesEs from '../locale/es.json';
+import { defaultCrossfadeDuration } from './constants/defaults';
 
 // polyfill to enable formatting of a number using the unit prop
 if (typeof Intl.NumberFormat.__addLocaleData === 'function') {
@@ -82,85 +85,107 @@ export default function App() {
       >
         <BrowserRouter basename="/">
           <ScrollToTop />
-          <main
-            style={{
-              height: '100%',
-              width: '100%',
-              justifyContent: 'center',
-              alignItems: 'center',
-              overflow: 'hidden',
-              minHeight: '100vh',
-            }}
-          >
+          <main>
             <AppHeader />
-            {siteSettings.needsSetup ? (
-              <SiteSetup />
-            ) : (
-              <Switch>
-                <Route path="/individuals/picturebook">
-                  <PictureBook />
-                </Route>
-                <Route path="/individuals/:id">
-                  <Individual />
-                </Route>
-                <Route path="/individuals">
-                  <SearchIndividuals />
-                </Route>
-                <Route path="/match/:id">
-                  <Match />
-                </Route>
-                <Route path="/sightings/:id">
-                  <Sighting />
-                </Route>
-                <Route path="/sightings">
-                  <SearchSightings />
-                </Route>
-                <Route path="/users/:id">
-                  <User />
-                </Route>
-                <Route path="/users">
-                  <Users />
-                </Route>
-                <Route path="/orgs/:id">
-                  <Org />
-                </Route>
-                <Route path="/orgs">
-                  <Orgs />
-                </Route>
-                <Route path="/report">
-                  <ReportSightings />
-                </Route>
-                <Route path="/administration">
-                  <Administration />
-                </Route>
-                <Route path="/forgot">
-                  <Forgot />
-                </Route>
-                <Route path="/login">
-                  <Login />
-                </Route>
-                <Route path="/logout">
-                  <Logout />
-                </Route>
-                <Route path="/request">
-                  <RequestInvitation />
-                </Route>
-                <Route path="/create">
-                  <CreateAccount />
-                </Route>
-                <Route path="/welcome">
-                  <Welcome />
-                </Route>
-                <Route path="/" exact>
-                  <Root />
-                </Route>
-                <Route>
-                  <FourOhFour />
-                </Route>
-              </Switch>
-            )}
+            <Route
+              render={({ location }) => (
+                <TransitionGroup appear component={null}>
+                  <Fade
+                    key={location.key}
+                    timeout={defaultCrossfadeDuration}
+                  >
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        overflow: 'hidden',
+                        boxSizing: 'border-box',
+                        width: '100%',
+                      }}
+                    >
+                      <div
+                        style={{
+                          minHeight: 'calc(100vh - 64px)',
+                          boxSizing: 'border-box',
+                        }}
+                      >
+                        {siteSettings.needsSetup ? (
+                          <SiteSetup />
+                        ) : (
+                          <Switch location={location}>
+                            <Route path="/individuals/picturebook">
+                              <PictureBook />
+                            </Route>
+                            <Route path="/individuals/:id">
+                              <Individual />
+                            </Route>
+                            <Route path="/individuals">
+                              <SearchIndividuals />
+                            </Route>
+                            <Route path="/match/:id">
+                              <Match />
+                            </Route>
+                            <Route path="/sightings/:id">
+                              <Sighting />
+                            </Route>
+                            <Route path="/sightings">
+                              <SearchSightings />
+                            </Route>
+                            <Route path="/users/:id">
+                              <User />
+                            </Route>
+                            <Route path="/users">
+                              <Users />
+                            </Route>
+                            <Route path="/orgs/:id">
+                              <Org />
+                            </Route>
+                            <Route path="/orgs">
+                              <Orgs />
+                            </Route>
+                            <Route path="/report">
+                              <ReportSightings />
+                            </Route>
+                            <Route path="/administration">
+                              <Administration />
+                            </Route>
+                            <Route path="/forgot">
+                              <Forgot />
+                            </Route>
+                            <Route path="/login">
+                              <Login />
+                            </Route>
+                            <Route path="/logout">
+                              <Logout />
+                            </Route>
+                            <Route path="/request">
+                              <RequestInvitation />
+                            </Route>
+                            <Route path="/create">
+                              <CreateAccount />
+                            </Route>
+                            <Route path="/welcome">
+                              <Welcome />
+                            </Route>
+                            <Route path="/" exact>
+                              <Root />
+                            </Route>
+                            <Route>
+                              <FourOhFour />
+                            </Route>
+                          </Switch>
+                        )}
+                      </div>
+                      <Footer />
+                    </div>
+                  </Fade>
+                </TransitionGroup>
+              )}
+            />
           </main>
-          <Footer />
         </BrowserRouter>
       </IntlProvider>
     </ThemeProvider>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -16,7 +16,7 @@ export default function Footer() {
   const dispatch = useDispatch();
 
   return (
-    <div style={{ width: '100%', paddingBottom: 16 }}>
+    <div id="footer" style={{ width: '100%', paddingBottom: 16 }}>
       <Divider />
       <div
         style={{

--- a/src/components/NotFoundPage.jsx
+++ b/src/components/NotFoundPage.jsx
@@ -31,6 +31,7 @@ export default function NotFoundPage({
         color: 'white',
         backgroundImage: `url(${imageUrl})`,
         backgroundSize: 'cover',
+        position: 'relative',
       }}
     >
       <div
@@ -53,7 +54,7 @@ export default function NotFoundPage({
           {details}
         </Typography>
       </div>
-      <div style={{ position: 'absolute', bottom: 12, left: 12 }}>
+      <div style={{ position: 'absolute', bottom: '8%', left: 12 }}>
         <Typography>
           <FormattedMessage id="PHOTO_BY" />
           <Link external href={artistUrl}>

--- a/src/constants/defaults.js
+++ b/src/constants/defaults.js
@@ -4,3 +4,5 @@ export const defaultAreaBounds = {
   east: 14.857142857142884,
   west: -15.428571428571413,
 };
+
+export const defaultCrossfadeDuration = 500;

--- a/src/pages/individual/PictureBook.jsx
+++ b/src/pages/individual/PictureBook.jsx
@@ -54,15 +54,24 @@ function resetStylesForPrintingCSS(theme) {
   return css`
     @media screen {
       body {
-        padding: 1rem;
+        padding: 0;
         max-width: ${theme.breakpoints.values.lg}px;
+      }
+
+      main > div:first-of-type {
+        padding: 1rem;
       }
     }
 
     /* visually removes header and footer */
     main > header.MuiAppBar-root,
-    #root > div {
+    main #footer {
       display: none;
+    }
+
+    /* repositions content at top of page */
+    main > div:first-of-type {
+      top: 0 !important;
     }
   `;
 }

--- a/src/pages/report/BulkReport.jsx
+++ b/src/pages/report/BulkReport.jsx
@@ -60,7 +60,7 @@ export default function BulkReport({ onBack, files }) {
       : enabledFields.join(',');
 
   return (
-    <Grid container direction="column">
+    <>
       <TermsAndConditionsDialog
         visible={dialogOpen}
         onClose={() => setDialogOpen(false)}
@@ -281,6 +281,6 @@ export default function BulkReport({ onBack, files }) {
           </Typography>
         )}
       </Grid>
-    </Grid>
+    </>
   );
 }

--- a/src/pages/report/ReportSightings.jsx
+++ b/src/pages/report/ReportSightings.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
 
@@ -10,6 +10,8 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
 import Drawer from '@material-ui/core/Drawer';
+import Fade from '@material-ui/core/Fade';
+import { TransitionGroup } from 'react-transition-group';
 
 import { selectIsAuthenticated } from '../../modules/app/selectors';
 import MainColumn from '../../components/MainColumn';
@@ -20,15 +22,30 @@ import Button from '../../components/Button';
 import StandardReport from './StandardReport';
 import BulkReport from './BulkReport';
 import UploadManager from './UploadManager';
+import { defaultCrossfadeDuration } from '../../constants/defaults';
 
 export default function ReportSightings() {
   useDocumentTitle('Report Encounters');
   const isAuthenticated = useSelector(selectIsAuthenticated);
 
+  const contentRef = useRef(null);
+
   const [mode, setMode] = useState('');
   const [files, setFiles] = useState([]);
   const [reporting, setReporting] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(!isAuthenticated);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  // workound for ensuring that absolutely positioned content doesn't
+  // run into the footer.
+  useEffect(() => {
+    if (contentRef.current) {
+      const { height } = contentRef.current.getBoundingClientRect();
+      if (height !== contentHeight) {
+        setContentHeight(height);
+      }
+    }
+  });
 
   const noImages = mode !== '' && files.length === 0;
 
@@ -84,110 +101,136 @@ export default function ReportSightings() {
             <FormattedMessage id="REPORT_SIGHTINGS" />
           </Typography>
         </Grid>
-        {!reporting && (
-          <>
-            <Grid item>
-              <FormControl component="fieldset">
-                <RadioGroup
-                  aria-label="sharing"
-                  name="sharing"
-                  value={mode}
-                >
-                  <FormControlLabel
-                    value="one"
-                    control={<Radio />}
-                    onClick={e => {
-                      if (e.target.value) setMode(e.target.value);
-                    }}
-                    label={
-                      <FormattedMessage id="ONE_SIGHTING_ONE_INDIVIDUAL" />
-                    }
-                  />
-                  <Typography variant="caption">
-                    <FormattedMessage id="ONE_SIGHTING_ONE_INDIVIDUAL_DESCRIPTION" />
-                  </Typography>
-                  <FormControlLabel
-                    value="multiple"
-                    control={<Radio />}
-                    onClick={e => {
-                      if (e.target.value) setMode(e.target.value);
-                    }}
-                    label={
-                      <FormattedMessage id="ONE_SIGHTING_MULTIPLE_INDIVIDUALS" />
-                    }
-                  />
-                  <Typography variant="caption">
-                    <FormattedMessage id="ONE_SIGHTING_MULTIPLE_INDIVIDUALS_DESCRIPTION" />
-                  </Typography>
-                  <FormControlLabel
-                    value="bulk"
-                    control={<Radio />}
-                    onClick={e => {
-                      if (e.target.value) setMode(e.target.value);
-                    }}
-                    label={
-                      <FormattedMessage id="MULTIPLE_SIGHTINGS" />
-                    }
-                  />
-                  <Typography variant="caption">
-                    <FormattedMessage id="MULTIPLE_SIGHTINGS_DESCRIPTION" />
-                  </Typography>
-                </RadioGroup>
-              </FormControl>
-            </Grid>
+        <TransitionGroup
+          style={{
+            height: `${contentHeight}px`,
+            position: 'relative',
+          }}
+        >
+          <Fade
+            key={reporting}
+            timeout={defaultCrossfadeDuration}
+            ref={contentRef}
+          >
+            <Grid
+              item
+              container
+              direction="column"
+              style={{ position: 'absolute', top: 0, left: 0 }}
+            >
+              {!reporting && (
+                <>
+                  <Grid item>
+                    <FormControl component="fieldset">
+                      <RadioGroup
+                        aria-label="sharing"
+                        name="sharing"
+                        value={mode}
+                      >
+                        <FormControlLabel
+                          value="one"
+                          control={<Radio />}
+                          onClick={e => {
+                            if (e.target.value)
+                              setMode(e.target.value);
+                          }}
+                          label={
+                            <FormattedMessage id="ONE_SIGHTING_ONE_INDIVIDUAL" />
+                          }
+                        />
+                        <Typography variant="caption">
+                          <FormattedMessage id="ONE_SIGHTING_ONE_INDIVIDUAL_DESCRIPTION" />
+                        </Typography>
+                        <FormControlLabel
+                          value="multiple"
+                          control={<Radio />}
+                          onClick={e => {
+                            if (e.target.value)
+                              setMode(e.target.value);
+                          }}
+                          label={
+                            <FormattedMessage id="ONE_SIGHTING_MULTIPLE_INDIVIDUALS" />
+                          }
+                        />
+                        <Typography variant="caption">
+                          <FormattedMessage id="ONE_SIGHTING_MULTIPLE_INDIVIDUALS_DESCRIPTION" />
+                        </Typography>
+                        <FormControlLabel
+                          value="bulk"
+                          control={<Radio />}
+                          onClick={e => {
+                            if (e.target.value)
+                              setMode(e.target.value);
+                          }}
+                          label={
+                            <FormattedMessage id="MULTIPLE_SIGHTINGS" />
+                          }
+                        />
+                        <Typography variant="caption">
+                          <FormattedMessage id="MULTIPLE_SIGHTINGS_DESCRIPTION" />
+                        </Typography>
+                      </RadioGroup>
+                    </FormControl>
+                  </Grid>
 
-            {mode !== '' && (
-              <Grid item style={{ marginTop: 20 }}>
-                <UploadManager files={files} setFiles={setFiles} />
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    marginTop: 20,
-                  }}
-                >
-                  <InfoIcon
-                    fontSize="small"
-                    style={{ marginRight: 4 }}
-                  />
-                  <Typography variant="caption">
-                    <FormattedMessage id="PHOTO_OPTIMIZE_1" />
-                    <Link
-                      external
-                      href="http://wiki.wildbook.org/en/researchers/photography"
+                  {mode !== '' && (
+                    <Grid item style={{ marginTop: 20 }}>
+                      <UploadManager
+                        files={files}
+                        setFiles={setFiles}
+                      />
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          marginTop: 20,
+                        }}
+                      >
+                        <InfoIcon
+                          fontSize="small"
+                          style={{ marginRight: 4 }}
+                        />
+                        <Typography variant="caption">
+                          <FormattedMessage id="PHOTO_OPTIMIZE_1" />
+                          <Link
+                            external
+                            href="http://wiki.wildbook.org/en/researchers/photography"
+                          >
+                            <FormattedMessage id="PHOTO_OPTIMIZE_2" />
+                          </Link>
+                          <FormattedMessage id="PHOTO_OPTIMIZE_3" />
+                        </Typography>
+                      </div>
+                    </Grid>
+                  )}
+
+                  <Grid item>
+                    <Button
+                      display={noImages ? 'subtle' : 'primary'}
+                      disabled={!mode}
+                      onClick={() => setReporting(true)}
+                      style={{ marginTop: 16 }}
                     >
-                      <FormattedMessage id="PHOTO_OPTIMIZE_2" />
-                    </Link>
-                    <FormattedMessage id="PHOTO_OPTIMIZE_3" />
-                  </Typography>
-                </div>
-              </Grid>
-            )}
-
-            <Grid item>
-              <Button
-                display={noImages ? 'subtle' : 'primary'}
-                disabled={!mode}
-                onClick={() => setReporting(true)}
-                style={{ marginTop: 16 }}
-              >
-                <FormattedMessage
-                  id={
-                    noImages
-                      ? 'CONTINUE_WITHOUT_PHOTOGRAPHS'
-                      : 'CONTINUE'
-                  }
-                />
-              </Button>
+                      <FormattedMessage
+                        id={
+                          noImages
+                            ? 'CONTINUE_WITHOUT_PHOTOGRAPHS'
+                            : 'CONTINUE'
+                        }
+                      />
+                    </Button>
+                  </Grid>
+                </>
+              )}
+              {reporting && ['one', 'multiple'].includes(mode) && (
+                <StandardReport onBack={onBack} variant={mode} />
+              )}
+              {reporting && mode === 'bulk' && (
+                <BulkReport onBack={onBack} files={files} />
+              )}
             </Grid>
-          </>
-        )}
-        {reporting && ['one', 'multiple'].includes(mode) && (
-          <StandardReport onBack={onBack} variant={mode} />
-        )}
-        {reporting && mode === 'bulk' && (
-          <BulkReport onBack={onBack} files={files} />
-        )}
+          </Fade>
+        </TransitionGroup>
       </Grid>
     </MainColumn>
   );

--- a/src/pages/report/StandardReport.jsx
+++ b/src/pages/report/StandardReport.jsx
@@ -10,7 +10,6 @@ import Grid from '@material-ui/core/Grid';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import BackIcon from '@material-ui/icons/KeyboardBackspace';
 import {
   selectSightingSchema,
   selectSightingCategories,
@@ -43,7 +42,7 @@ export default function StandardReport({ variant, onBack }) {
   );
 
   return (
-    <Grid container direction="column">
+    <>
       <TermsAndConditionsDialog
         visible={dialogOpen}
         onClose={() => setDialogOpen(false)}
@@ -237,6 +236,6 @@ export default function StandardReport({ variant, onBack }) {
           </Typography>
         ))}
       </Grid>
-    </Grid>
+    </>
   );
 }


### PR DESCRIPTION
- The layout on the report sightings page is not pixel perfect to what it was before.
- I had to change the way the photo credit on the 404 page displayed because, after changing the layout for the transitions, it displayed on top of the footer. The way it is right now, it should always display over the picture, but not always within the initial screen view.