### PR TITLE
Dex 1080 multi select custom to string

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1148,5 +1148,9 @@
   "ONE_OR_MORE_ROLES_MISSING_LABELS": "One or more roles are missing labels",
   "TWO_OR_MORE_ROLES_SAME_LABEL": "Two or more roles have the same label. Make sure each label is different",
   "ROLE_GUID_MISSING": "Role is missing ID",
-  "UNFINISHED_OPTIONS": "Options must have valid values and labels and unique values"
+  "UNFINISHED_OPTIONS": "Options must have valid values and labels and unique values",
+  "MATCHED_OPTION_MESSAGE": "The following options(s) were found: {matchedOptionsString}.",
+  "UNMATCHED_OPTION_MESSAGE": "The following asset(s) were not found and will be ignored: {unmatchedOptionsString}.",
+  "MATCHED_ASSET_MESSAGE": "The following asset(s) were found: {matchedAssetsString}.",
+  "UNMATCHED_ASSET_MESSAGE": "The following asset(s) were not found and will be ignored: {unmatchedAssetsString}."
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -1149,8 +1149,8 @@
   "TWO_OR_MORE_ROLES_SAME_LABEL": "Two or more roles have the same label. Make sure each label is different",
   "ROLE_GUID_MISSING": "Role is missing ID",
   "UNFINISHED_OPTIONS": "Options must have valid values and labels and unique values",
-  "MATCHED_OPTION_MESSAGE": "The following options(s) were found: {matchedOptionsString}.",
-  "UNMATCHED_OPTION_MESSAGE": "The following asset(s) were not found and will be ignored: {unmatchedOptionsString}.",
-  "MATCHED_ASSET_MESSAGE": "The following asset(s) were found: {matchedAssetsString}.",
-  "UNMATCHED_ASSET_MESSAGE": "The following asset(s) were not found and will be ignored: {unmatchedAssetsString}."
+  "MATCHED_OPTION_MESSAGE": "The following options(s) were found: {results}.",
+  "UNMATCHED_OPTION_MESSAGE": "The following asset(s) were not found and will be ignored: {results}.",
+  "MATCHED_ASSET_MESSAGE": "The following asset(s) were found: {results}.",
+  "UNMATCHED_ASSET_MESSAGE": "The following asset(s) were not found and will be ignored: {results}."
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -1148,7 +1148,7 @@
   "ONE_OR_MORE_ROLES_MISSING_LABELS": "One or more roles are missing labels",
   "TWO_OR_MORE_ROLES_SAME_LABEL": "Two or more roles have the same label. Make sure each label is different",
   "ROLE_GUID_MISSING": "Role is missing ID",
-  "UNFINISHED_OPTIONS": "Options must have valid values and labels and unique values",
+  "UNFINISHED_OPTIONS": "Options must have valid values and labels. Values must be unique.",
   "MATCHED_OPTION_MESSAGE": "The following options(s) were found: {results}.",
   "UNMATCHED_OPTION_MESSAGE": "The following asset(s) were not found and will be ignored: {results}.",
   "MATCHED_ASSET_MESSAGE": "The following asset(s) were found: {results}.",

--- a/src/pages/bulkImport/BulkReportForm.jsx
+++ b/src/pages/bulkImport/BulkReportForm.jsx
@@ -140,7 +140,7 @@ export default function BulkReportForm({ assetReferences }) {
   const sightingFieldSchemas = useSightingFieldSchemas();
   const encounterFieldSchemas = useEncounterFieldSchemas();
 
-  const multiselectCustomFieldIds = reduce(
+  const multiselectFieldIds = reduce(
     [...sightingFieldSchemas, ...encounterFieldSchemas],
     (memo, currentSchema) => {
       if (currentSchema?.fieldType === 'multiselect')
@@ -156,9 +156,7 @@ export default function BulkReportForm({ assetReferences }) {
       const matches = field?.key?.match(
         /custom-(encounter|sighting|individual)-(.*)/,
       ); // I imagine that there's a way to generalize this to work with deriveCustomFieldPrefix, but I played around with new regExp() using variables, and couldn't seem to get it to work. Would love some help with this.
-      return multiselectCustomFieldIds.includes(
-        matches && matches[2],
-      );
+      return multiselectFieldIds.includes(matches && matches[2]);
     },
   );
 

--- a/src/pages/bulkImport/BulkReportForm.jsx
+++ b/src/pages/bulkImport/BulkReportForm.jsx
@@ -146,6 +146,8 @@ export default function BulkReportForm({ assetReferences }) {
   const matchingCustomMultiselects = filter(
     availableFields,
     field => {
+      // const re = new RegExp('custom-(encounter|sighting)-(.*)', 'g');
+      // const matches = field?.key?.match(re); // TODO deleteMe generalize this using the below
       const matches = field?.key?.match(
         /custom-(encounter|sighting)-(.*)/,
       ); // TODO deleteMe generalize this using the below

--- a/src/pages/bulkImport/BulkReportForm.jsx
+++ b/src/pages/bulkImport/BulkReportForm.jsx
@@ -98,8 +98,6 @@ async function onRecordChange(record, recordIndex, filenames, intl) {
       intl,
     );
     const assetMessage = get(assetValidationResponse, [0, 0]);
-    console.log('deleteMe assetMessage is: ');
-    console.log(assetMessage);
     if (assetMessage) {
       messages = { ...messages, assetReferences: assetMessage };
     }

--- a/src/pages/bulkImport/utils/bulkImportFormatters.js
+++ b/src/pages/bulkImport/utils/bulkImportFormatters.js
@@ -1,3 +1,14 @@
+import {
+  get,
+  filter,
+  reduce,
+  map,
+  keyBy,
+  mapValues,
+} from 'lodash-es';
+
+import { validateStrings } from './flatfileValidators';
+
 export const formatDuplicateLabel = (currentLabel, key, intl) => {
   let returnLabel = currentLabel;
   if (key.startsWith('custom-sighting'))
@@ -13,4 +24,65 @@ export const formatDuplicateLabel = (currentLabel, key, intl) => {
       { label: currentLabel },
     );
   return returnLabel;
+};
+
+export const generateCustomMultiselectFlatFileHooks = (
+  customMultiselects,
+  intl,
+) => {
+  const safeWellKeyedCustomMultiselects =
+    keyBy(customMultiselects, 'key') || [];
+
+  const customFieldHooks = mapValues(
+    safeWellKeyedCustomMultiselects,
+    customMultiselectField => {
+      const options = get(customMultiselectField, 'options', []).map(
+        opt => opt?.value,
+      );
+      return values =>
+        validateStrings(
+          options,
+          values,
+          'MATCHED_OPTION_MESSAGE',
+          'UNMATCHED_OPTION_MESSAGE',
+          intl,
+        );
+    },
+  );
+
+  return customFieldHooks;
+};
+
+export const addValidMultiselectOptionsToSightingData = (
+  sightingData,
+  customMultiselects,
+) => {
+  const validatedSightingData = map(sightingData, sighting => {
+    const multiselectCustomFields = reduce(
+      customMultiselects,
+      (memo, currentMultiSelectField) => {
+        const currentSightingOpts =
+          get(sighting, [currentMultiSelectField?.key])
+            ?.split(',')
+            ?.map(opt => opt.trim()) || [];
+        const allValidOpts =
+          get(currentMultiSelectField, ['options'])?.map(
+            validOptObj => validOptObj?.label,
+          ) || [];
+        const validCurrentSightingOpts = filter(
+          currentSightingOpts,
+          currentSightingOpt =>
+            allValidOpts.includes(currentSightingOpt),
+        );
+        const newField = {};
+        newField[
+          (currentMultiSelectField?.key)
+        ] = validCurrentSightingOpts;
+        return { ...memo, ...newField };
+      },
+      {},
+    );
+    return { ...sighting, ...multiselectCustomFields };
+  });
+  return validatedSightingData;
 };

--- a/src/pages/bulkImport/utils/flatfileValidators.js
+++ b/src/pages/bulkImport/utils/flatfileValidators.js
@@ -55,9 +55,9 @@ export function validateStrings(
 ) {
   const validationMessages = stringInputs.map(stringInput => {
     const [str, rowIndex] = stringInput;
-    const strs = parseBulkImportString(str);
-    if (strs.length === 0) return null;
-    const [matchedStrs, unmatchedStrs] = partition(strs, a =>
+    const parsedString = parseBulkImportString(str);
+    if (parsedString.length === 0) return null;
+    const [matchedStrs, unmatchedStrs] = partition(parsedString, a =>
       validEntries.includes(a),
     );
     const matchedString = matchedStrs.join(', ');

--- a/src/pages/bulkImport/utils/flatfileValidators.js
+++ b/src/pages/bulkImport/utils/flatfileValidators.js
@@ -51,16 +51,28 @@ export function validateAssetStrings(
   assetStringInputs,
   intl,
 ) {
+  console.log('deleteMe intl is: ');
+  console.log(intl);
   const validationMessages = assetStringInputs.map(
     assetStringInput => {
+      console.log('deleteMe assetStringInput is: ');
+      console.log(assetStringInput);
       const [assetString, rowIndex] = assetStringInput;
       const assets = parseBulkImportString(assetString);
+      console.log('deleteMe assets are: ');
+      console.log(assets);
       if (assets.length === 0) return null;
       const [matchedAssets, unmatchedAssets] = partition(assets, a =>
         filenames.includes(a),
       );
+      console.log('deleteMe matchedAssets are: ');
+      console.log(matchedAssets);
+      console.log('deleteMe unmatchedAssets are: ');
+      console.log(unmatchedAssets);
 
       const matchedAssetsString = matchedAssets.join(', ');
+      console.log('deleteMe matchedAssetsString is: ');
+      console.log(matchedAssetsString);
       const unmatchedAssetsString = unmatchedAssets.join(', ');
       const matchedAssetsMessage = intl.formatMessage(
         {
@@ -80,6 +92,8 @@ export function validateAssetStrings(
       message = message.concat(
         unmatchedAssets.length > 0 ? unmatchedAssetsMessage : '',
       );
+      console.log('deleteMe message is: ');
+      console.log(message);
 
       const level = unmatchedAssets.length > 0 ? 'warning' : 'info';
 
@@ -103,6 +117,11 @@ export function validateCustomMultiSelectStrings( // TODO deleteMe somehow DRY w
   customMultiselectInputs,
   intl,
 ) {
+  console.log('deleteMe entered validateCustomMultiSelectStrings');
+  console.log('deleteMe optionObjs are: ');
+  console.log(optionObjs);
+  console.log('deleteMe customMultiselectInputs are: ');
+  console.log(customMultiselectInputs);
   const options = map(optionObjs, optionObj => optionObj?.value);
   const validationMessages = customMultiselectInputs.map(
     customMultiselectInput => {

--- a/src/pages/bulkImport/utils/flatfileValidators.js
+++ b/src/pages/bulkImport/utils/flatfileValidators.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
-import { partition } from 'lodash-es';
+import { partition, map } from 'lodash-es';
 
-import parseAssetString from './parseAssetString';
+import parseBulkImportString from './parseBulkImportString';
 
 export async function validateIndividualNames(names) {
   const response = await axios.request({
@@ -46,11 +46,15 @@ export function validateMinMax(record) {
   return recordHookResponse;
 }
 
-export function validateAssetStrings(filenames, assetStringInputs) {
+export function validateAssetStrings(
+  filenames,
+  assetStringInputs,
+  intl,
+) {
   const validationMessages = assetStringInputs.map(
     assetStringInput => {
       const [assetString, rowIndex] = assetStringInput;
-      const assets = parseAssetString(assetString);
+      const assets = parseBulkImportString(assetString);
       if (assets.length === 0) return null;
       const [matchedAssets, unmatchedAssets] = partition(assets, a =>
         filenames.includes(a),
@@ -58,8 +62,18 @@ export function validateAssetStrings(filenames, assetStringInputs) {
 
       const matchedAssetsString = matchedAssets.join(', ');
       const unmatchedAssetsString = unmatchedAssets.join(', ');
-      const matchedAssetsMessage = `The following asset(s) were found: ${matchedAssetsString}.`;
-      const unmatchedAssetsMessage = ` The following asset(s) were not found and will be ignored: ${unmatchedAssetsString}.`;
+      const matchedAssetsMessage = intl.formatMessage(
+        {
+          id: 'MATCHED_ASSET_MESSAGE',
+        },
+        { matchedAssetsString },
+      );
+      const unmatchedAssetsMessage = intl.formatMessage(
+        {
+          id: 'UNMATCHED_ASSET_MESSAGE',
+        },
+        { unmatchedAssetsString },
+      );
 
       let message =
         matchedAssets.length > 0 ? matchedAssetsMessage : '';
@@ -68,6 +82,58 @@ export function validateAssetStrings(filenames, assetStringInputs) {
       );
 
       const level = unmatchedAssets.length > 0 ? 'warning' : 'info';
+
+      const rowMessage = {
+        info: [
+          {
+            message,
+            level,
+          },
+        ],
+      };
+      return [rowMessage, rowIndex];
+    },
+  );
+
+  return validationMessages.filter(message => message);
+}
+
+export function validateCustomMultiSelectStrings( // TODO deleteMe somehow DRY with the above
+  optionObjs,
+  customMultiselectInputs,
+  intl,
+) {
+  const options = map(optionObjs, optionObj => optionObj?.value);
+  const validationMessages = customMultiselectInputs.map(
+    customMultiselectInput => {
+      const [optionString, rowIndex] = customMultiselectInput;
+      const customOptions = parseBulkImportString(optionString);
+      if (customOptions.length === 0) return null;
+      const [matchedOptions, unmatchedOptions] = partition(
+        customOptions,
+        a => options.includes(a),
+      );
+
+      const matchedOptionsString = matchedOptions.join(', ');
+      const unmatchedOptionsString = unmatchedOptions.join(', ');
+      const matchedOptionMessage = intl.formatMessage(
+        { id: 'MATCHED_OPTION_MESSAGE' },
+        { matchedOptionsString },
+      );
+      const unmatchedOptionMessage = intl.formatMessage(
+        {
+          id: 'UNMATCHED_OPTION_MESSAGE',
+        },
+        { unmatchedOptionsString },
+      );
+
+      let message =
+        matchedOptions.length > 0 ? matchedOptionMessage : '';
+      message = message.concat(
+        unmatchedOptions.length > 0 ? unmatchedOptionMessage : '',
+      );
+
+      const level = unmatchedOptions.length > 0 ? 'warning' : 'info';
 
       const rowMessage = {
         info: [

--- a/src/pages/bulkImport/utils/parseAssetString.js
+++ b/src/pages/bulkImport/utils/parseAssetString.js
@@ -1,6 +1,0 @@
-export default function parseAssetString(assetString) {
-  const phrasesBetweenCommas = assetString
-    .split(',')
-    .map(a => a.trim());
-  return phrasesBetweenCommas.filter(phrase => phrase !== '');
-}

--- a/src/pages/bulkImport/utils/parseBulkImportString.js
+++ b/src/pages/bulkImport/utils/parseBulkImportString.js
@@ -1,0 +1,6 @@
+export default function parseBulkImportString(bulkImportString) {
+  const phrasesBetweenCommas = bulkImportString
+    .split(',')
+    .map(a => a.trim());
+  return phrasesBetweenCommas.filter(phrase => phrase !== '');
+}

--- a/src/pages/bulkImport/utils/prepareAssetGroup.js
+++ b/src/pages/bulkImport/utils/prepareAssetGroup.js
@@ -11,7 +11,7 @@ import { v4 as uuid } from 'uuid';
 import { formatHoustonTime } from '../../../utils/formatters';
 import categoryTypes from '../../../constants/categoryTypes';
 import { deriveCustomFieldPrefix } from '../constants/bulkReportConstants';
-import parseAssetString from './parseAssetString';
+import parseBulkImportString from './parseBulkImportString';
 
 function updateTimes(encounter) {
   const year = get(encounter, 'timeYear', 0);
@@ -36,6 +36,17 @@ function deriveCustomFields(encounter, categoryType) {
     encounter,
     (value, key) => value && startsWith(key, prefix),
   );
+  console.log(
+    'deleteMe customSightingFields in deriveCustomFields are: ',
+  );
+  console.log(customSightingFields);
+
+  const deleteMeReturnVal = mapKeys(
+    customSightingFields,
+    (_, key) => key.split(prefix)[1],
+  );
+  console.log('deleteMe deleteMeReturnVal is: ');
+  console.log(deleteMeReturnVal);
 
   return mapKeys(
     customSightingFields,
@@ -73,6 +84,10 @@ export default function prepareAssetGroup(
   encounters,
   assetReferences,
 ) {
+  console.log('deleteMe encounters are: ');
+  console.log(encounters);
+  console.log('deleteMe assetReferences are: ');
+  console.log(assetReferences);
   const sightings = {};
   const simpleAssetReferences = assetReferences.map(a => a.path);
   encounters.forEach(encounter => {
@@ -84,7 +99,7 @@ export default function prepareAssetGroup(
       'assetReferences',
       '',
     );
-    const sightingAssets = parseAssetString(sightingAssetInput);
+    const sightingAssets = parseBulkImportString(sightingAssetInput);
     const matchingAssets = simpleAssetReferences.filter(path =>
       sightingAssets.includes(path),
     );
@@ -139,6 +154,8 @@ export default function prepareAssetGroup(
       newEncounter,
       categoryTypes.sighting,
     );
+    console.log('deleteMe customSightingFields are: ');
+    console.log(customSightingFields);
     if (!isEmpty(customSightingFields)) {
       sightings[sightingId].customFields = customSightingFields;
     }
@@ -150,9 +167,13 @@ export default function prepareAssetGroup(
       newEncounter,
       categoryTypes.encounter,
     );
+    console.log('deleteMe customEncounterFields are: ');
+    console.log(customEncounterFields);
     if (!isEmpty(customEncounterFields)) {
       newEncounter.customFields = customEncounterFields;
     }
+    console.log('deleteMe newEncounter near the end is: ');
+    console.log(newEncounter);
 
     const finalEncounter = omit(newEncounter, [
       'sightingId',
@@ -167,6 +188,10 @@ export default function prepareAssetGroup(
       ...deriveCustomFieldKeys(newEncounter),
     ]);
     sightings[sightingId].encounters.push(finalEncounter);
+    console.log('deleteMe finalEncounter is: ');
+    console.log(finalEncounter);
+    console.log('deleteMe final sightings are: ');
+    console.log(sightings);
   });
 
   return Object.values(sightings);

--- a/src/pages/bulkImport/utils/prepareAssetGroup.js
+++ b/src/pages/bulkImport/utils/prepareAssetGroup.js
@@ -36,17 +36,6 @@ function deriveCustomFields(encounter, categoryType) {
     encounter,
     (value, key) => value && startsWith(key, prefix),
   );
-  console.log(
-    'deleteMe customSightingFields in deriveCustomFields are: ',
-  );
-  console.log(customSightingFields);
-
-  const deleteMeReturnVal = mapKeys(
-    customSightingFields,
-    (_, key) => key.split(prefix)[1],
-  );
-  console.log('deleteMe deleteMeReturnVal is: ');
-  console.log(deleteMeReturnVal);
 
   return mapKeys(
     customSightingFields,
@@ -84,10 +73,6 @@ export default function prepareAssetGroup(
   encounters,
   assetReferences,
 ) {
-  console.log('deleteMe encounters are: ');
-  console.log(encounters);
-  console.log('deleteMe assetReferences are: ');
-  console.log(assetReferences);
   const sightings = {};
   const simpleAssetReferences = assetReferences.map(a => a.path);
   encounters.forEach(encounter => {
@@ -154,8 +139,6 @@ export default function prepareAssetGroup(
       newEncounter,
       categoryTypes.sighting,
     );
-    console.log('deleteMe customSightingFields are: ');
-    console.log(customSightingFields);
     if (!isEmpty(customSightingFields)) {
       sightings[sightingId].customFields = customSightingFields;
     }
@@ -167,13 +150,9 @@ export default function prepareAssetGroup(
       newEncounter,
       categoryTypes.encounter,
     );
-    console.log('deleteMe customEncounterFields are: ');
-    console.log(customEncounterFields);
     if (!isEmpty(customEncounterFields)) {
       newEncounter.customFields = customEncounterFields;
     }
-    console.log('deleteMe newEncounter near the end is: ');
-    console.log(newEncounter);
 
     const finalEncounter = omit(newEncounter, [
       'sightingId',
@@ -188,10 +167,6 @@ export default function prepareAssetGroup(
       ...deriveCustomFieldKeys(newEncounter),
     ]);
     sightings[sightingId].encounters.push(finalEncounter);
-    console.log('deleteMe finalEncounter is: ');
-    console.log(finalEncounter);
-    console.log('deleteMe final sightings are: ');
-    console.log(sightings);
   });
 
   return Object.values(sightings);

--- a/src/pages/bulkImport/utils/useBulkImportFields.js
+++ b/src/pages/bulkImport/utils/useBulkImportFields.js
@@ -65,12 +65,11 @@ export default function useBulkImportFields() {
     );
     return bulkSightingFields.map(f => {
       const additionalProperties = {};
-      if (
-        f?.fieldType === 'select' ||
-        f?.fieldType === 'multiselect'
-      ) {
+      if (f?.fieldType === 'select') {
         additionalProperties.type = 'select';
       }
+      if (f?.fieldType === 'multiselect')
+        additionalProperties.type = 'string';
       if (f?.choices) additionalProperties.options = f.choices;
       if (f.name === 'locationId') {
         additionalProperties.type = 'select';
@@ -95,12 +94,11 @@ export default function useBulkImportFields() {
     );
     return bulkEncounterFields.map(f => {
       const additionalProperties = {};
-      if (
-        f?.fieldType === 'select' ||
-        f?.fieldType === 'multiselect'
-      ) {
+      if (f?.fieldType === 'select') {
         additionalProperties.type = 'select';
       }
+      if (f?.fieldType === 'multiselect')
+        additionalProperties.type = 'string';
       if (f?.choices) additionalProperties.options = f.choices;
       if (f.name === 'taxonomy') {
         additionalProperties.type = 'select';

--- a/src/pages/bulkImport/utils/useBulkImportFields.js
+++ b/src/pages/bulkImport/utils/useBulkImportFields.js
@@ -82,8 +82,6 @@ export default function useBulkImportFields() {
         return {
           label: deriveLabel(f, intl),
           key: deriveKey(f, categoryTypes.sighting),
-          // customField: Boolean(f?.customField),
-          // fieldType: f?.fieldType,
           ...additionalProperties,
         };
       });
@@ -124,8 +122,6 @@ export default function useBulkImportFields() {
         return {
           label: deriveLabel(f, intl),
           key: deriveKey(f, categoryTypes.encounter),
-          // customField: Boolean(f?.customField),
-          // fieldType: f?.fieldType,
           ...additionalProperties,
         };
       });

--- a/src/pages/bulkImport/utils/useBulkImportFields.js
+++ b/src/pages/bulkImport/utils/useBulkImportFields.js
@@ -58,66 +58,80 @@ export default function useBulkImportFields() {
   const intl = useIntl();
   const { regionOptions, speciesOptions } = useOptions();
   const sightingFieldSchemas = useSightingFieldSchemas();
-  const flatfileSightingFields = useMemo(() => {
-    if (!sightingFieldSchemas) return {};
-    const bulkSightingFields = sightingFieldSchemas.filter(
-      f => !sightingOmitList.includes(f.name),
-    );
-    return bulkSightingFields.map(f => {
-      const additionalProperties = {};
-      if (f?.fieldType === 'select') {
-        additionalProperties.type = 'select';
-      }
-      if (f?.fieldType === 'multiselect')
-        additionalProperties.type = 'string';
-      if (f?.choices) additionalProperties.options = f.choices;
-      if (f.name === 'locationId') {
-        additionalProperties.type = 'select';
-        additionalProperties.options = regionOptions;
-        additionalProperties.validators = [requiredValidator];
-      }
-      return {
-        label: deriveLabel(f, intl),
-        key: deriveKey(f, categoryTypes.sighting),
-        ...additionalProperties,
-      };
-    });
-  }, [intl, sightingFieldSchemas, regionOptions]);
+  const flatfileSightingFields = useMemo(
+    () => {
+      if (!sightingFieldSchemas) return {};
+      const bulkSightingFields = sightingFieldSchemas.filter(
+        f => !sightingOmitList.includes(f.name),
+      );
+      return bulkSightingFields.map(f => {
+        const additionalProperties = {};
+        additionalProperties.customField = Boolean(f?.customField);
+        additionalProperties.fieldType = f?.fieldType;
+        if (f?.fieldType === 'select') {
+          additionalProperties.type = 'select';
+        }
+        if (f?.fieldType === 'multiselect')
+          additionalProperties.type = 'string';
+        if (f?.choices) additionalProperties.options = f.choices;
+        if (f.name === 'locationId') {
+          additionalProperties.type = 'select';
+          additionalProperties.options = regionOptions;
+          additionalProperties.validators = [requiredValidator];
+        }
+        return {
+          label: deriveLabel(f, intl),
+          key: deriveKey(f, categoryTypes.sighting),
+          // customField: Boolean(f?.customField),
+          // fieldType: f?.fieldType,
+          ...additionalProperties,
+        };
+      });
+    },
+    [intl, sightingFieldSchemas, regionOptions],
+  );
 
   const encounterFieldSchemas = useEncounterFieldSchemas();
 
-  const flatfileEncounterFields = useMemo(() => {
-    if (!encounterFieldSchemas || !regionOptions || !speciesOptions)
-      return {};
-    const bulkEncounterFields = encounterFieldSchemas.filter(
-      f => !encounterOmitList.includes(f.name),
-    );
-    return bulkEncounterFields.map(f => {
-      const additionalProperties = {};
-      if (f?.fieldType === 'select') {
-        additionalProperties.type = 'select';
-      }
-      if (f?.fieldType === 'multiselect')
-        additionalProperties.type = 'string';
-      if (f?.choices) additionalProperties.options = f.choices;
-      if (f.name === 'taxonomy') {
-        additionalProperties.type = 'select';
-        additionalProperties.options = speciesOptions;
-      }
-      if (f.name === 'sex') {
-        const sanitizedSexOptions = Object.values(
-          omitBy(sexOptions, sex => sex?.labelId === 'BLANK'),
-        );
-        additionalProperties.type = 'select';
-        additionalProperties.options = sanitizedSexOptions;
-      }
-      return {
-        label: deriveLabel(f, intl),
-        key: deriveKey(f, categoryTypes.encounter),
-        ...additionalProperties,
-      };
-    });
-  }, [intl, encounterFieldSchemas, speciesOptions]);
+  const flatfileEncounterFields = useMemo(
+    () => {
+      if (!encounterFieldSchemas || !regionOptions || !speciesOptions)
+        return {};
+      const bulkEncounterFields = encounterFieldSchemas.filter(
+        f => !encounterOmitList.includes(f.name),
+      );
+      return bulkEncounterFields.map(f => {
+        const additionalProperties = {};
+        additionalProperties.customField = Boolean(f?.customField);
+        additionalProperties.fieldType = f?.fieldType;
+        if (f?.fieldType === 'select') {
+          additionalProperties.type = 'select';
+        }
+        if (f?.fieldType === 'multiselect')
+          additionalProperties.type = 'string';
+        if (f?.choices) additionalProperties.options = f.choices;
+        if (f.name === 'taxonomy') {
+          additionalProperties.type = 'select';
+          additionalProperties.options = speciesOptions;
+        }
+        if (f.name === 'sex') {
+          const sanitizedSexOptions = Object.values(
+            omitBy(sexOptions, sex => sex?.labelId === 'BLANK'),
+          );
+          additionalProperties.type = 'select';
+          additionalProperties.options = sanitizedSexOptions;
+        }
+        return {
+          label: deriveLabel(f, intl),
+          key: deriveKey(f, categoryTypes.encounter),
+          // customField: Boolean(f?.customField),
+          // fieldType: f?.fieldType,
+          ...additionalProperties,
+        };
+      });
+    },
+    [intl, encounterFieldSchemas, speciesOptions],
+  );
 
   const additionalFlatfileFields = [
     {


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] All text is internationalized
- [x] There are no linter errors
- [x] New features support all states (loading, error, etc)
    - N/A

Which JIRA ticket(s) and/or GitHub issues does this PR address?
DEX-1080

Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.

# Description of things this PR does

1. Generalizes validateAssetStrings to validateStrings, so that it also worked for other string fields (including custom multi-select-but-actually-secretly-string fields).
2. Adds a new vectorizeCustomMultiselect method in BulkReportForm that transforms the text data from the bulk import into the array version that the BE is expecting for multi-select fields. Note that I decided against performing this transformation in prepareAssetGroup.js because the actual call of it needed availableFields, and that relied on a hook that I couldn't get in a non-component file.
3. Note also in said vectorizeCustomMultiselect that there's a forEach nested inside a reduce. I could not think of a solution here that didn't end up mutating the original sightingData object and would love some suggestions about this.
4. Internationalizes validateStrings (formerly validateAssetStrings).
5. Adds logic in BulkReportForm.jsx that identifies multi-select fields that have the custom-(encounter|sighting|individual)... regex logic (and are therefore custom multi-select fields), and then creates an object that follows the fieldHook pattern for firstName and assetReferences to be handled by FlatFile, and passes it to FlatFile's fieldHooks prop. Note that I am not satisfied with the hard-coded regex here but had difficulty generalizing it and would welcome help here.
6. Renames parseAssetString to parseBulkImportString because it now also gets used by the custom multiselect fields.
7. Changes the type property of bulk import fields with fieldType === 'multiselect' from 'select' to 'string'.

# QA Notes:

End users should now be warned about options in their bulk import spreadsheets in custom fields that don't match those that are populated in the platform:

<img width="1840" alt="Screen Shot 2022-07-20 at 11 33 36 AM" src="https://user-images.githubusercontent.com/2775448/180077283-ce60f0fa-4ed0-403e-9621-60e0fd703dd3.png">

These invalid options should be ignored during bulk import.

Ends users should also be informed of which options in their bulk import spreadsheets in custom fields DO match:

<img width="1840" alt="Screen Shot 2022-07-20 at 11 40 16 AM" src="https://user-images.githubusercontent.com/2775448/180077406-dfbd2ff7-8d41-4e44-bda2-5bf92e5eecf8.png">

End users should now see options entered as comma-separated entries in the relevant multi-select custom field column (e..g, Sighting-Behavior or Animal-Behavior in the case of zebra codex) appear as separate multi-select options on codex. This is in contrast to the old behavior, which only took the first entry and completely dropped the rest (i.e., the below would have simply been "Drinking" before this PR was merged):

<img width="1840" alt="Screen Shot 2022-07-20 at 11 40 44 AM" src="https://user-images.githubusercontent.com/2775448/180077524-10a5f699-17fd-419e-9de0-88244e41a935.png">




